### PR TITLE
Disabling the current trip interrupt 

### DIFF
--- a/src/M2_12VIO.cpp
+++ b/src/M2_12VIO.cpp
@@ -469,7 +469,7 @@ uint16_t M2_12VIO::Reset_Current_Limit(){
 
 /**
 * \brief
-*	Disable the Current Trip Intterupt, prevents the output from being disabled due to faults or transients
+*	Disable the Current Trip Interrupt, prevents the output from being disabled due to faults or transients
 *	WARNING, you will only have the (relatively) slow PTC fuse to protect your outputs
 * \param NIL
 * \return void

--- a/src/M2_12VIO.cpp
+++ b/src/M2_12VIO.cpp
@@ -467,6 +467,16 @@ uint16_t M2_12VIO::Reset_Current_Limit(){
 	return(M2_12VIO::Enable_12VIO_Monitor(ON));
 }
 
+/**
+* \brief
+*	Disable the Current Trip Intterupt, prevents the output from being disabled due to faults or transients
+*	WARNING, you will only have the (relatively) slow PTC fuse to protect your outputs
+* \param NIL
+* \return void
+*/
+uint16_t M2_12VIO::Disable_Current_Trip(){
+	detachInterrupt(digitalPinToInterrupt(Interupt_Over_Current));
+}
 
 /*
 *\brief

--- a/src/M2_12VIO.cpp
+++ b/src/M2_12VIO.cpp
@@ -467,6 +467,16 @@ uint16_t M2_12VIO::Reset_Current_Limit(){
 	return(M2_12VIO::Enable_12VIO_Monitor(ON));
 }
 
+/**
+* \brief
+*	Disable the Current Trip Intterupt, prevents the output from being disabled due to faults or transients
+*	WARNING, you will only have the (relatively) slow PTC fuse to protect your outputs
+* \param NIL
+* \return void
+*/
+void M2_12VIO::Disable_Current_Trip(){
+	detachInterrupt(digitalPinToInterrupt(Interupt_Over_Current));
+}
 
 /*
 *\brief

--- a/src/M2_12VIO.h
+++ b/src/M2_12VIO.h
@@ -247,6 +247,7 @@ class M2_12VIO{
 
 		uint16_t Init_12VIO();
 		uint16_t Reset_Current_Limit();
+		void Disable_Current_Trip();
         uint16_t Sleep(uint8_t Sleep_Mode);
 		uint32_t Load_Amps();
 		uint32_t Supply_Volts();

--- a/src/keywords.txt
+++ b/src/keywords.txt
@@ -12,6 +12,7 @@
 #######################################
 Init_12VIO()	 KEYWORD2
 Reset_Current_Limit()	KEYWORD2
+Disable_Current_Trip()	KEYWORD2
 Load_Amps()	 KEYWORD2
 Supply_Volts()	 KEYWORD2
 Read_12VIO(IO_Pin)	 KEYWORD2


### PR DESCRIPTION
Added a tiny function to allow the detaching of the current trip interrupt. 

I was having some issues with the GPIO powering up my external circuit and even with the circuit at about ~50mA constant, I believe the startup transient current spike was triggering the current limit circuit. 
My quick solution was to simply disable the current trip interrupt. I have added the function into the lib for others to use. 
Warning: using this function means the current trip will not activate on overload and you will be relying on the PTC fuse. 

A (likely better) alternative would be to turn the current limit reference DAC up to max for a short delay during boot, then returning to the per channel multiplied limit. 